### PR TITLE
chore: temp bump eest branch

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -51,7 +51,7 @@ env:
   S3_PUBLIC_URL: https://hive.ethpandaops.io/eof-devnet-0
   INSTALL_RCLONE_VERSION: v1.68.2
   EEST_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-spec-tests/releases/download/v4.1.0/fixtures_eip7692.tar.gz
-  EEST_BUILD_ARG_BRANCH: chore-osaka-ruleset
+  EEST_BUILD_ARG_BRANCH: main
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
     --client.checktimelimit=180s


### PR DESCRIPTION
Bumps the branch to main for now. This will be updated to the next stable release.